### PR TITLE
fixed delete mass message api. msgid to msg_id

### DIFF
--- a/lib/api_mass_send.js
+++ b/lib/api_mass_send.js
@@ -419,7 +419,7 @@ exports.deleteMass = function (messageId, callback) {
 
 exports._deleteMass = function (messageId, callback) {
   var opts = {
-    msgid: messageId
+    msg_id: messageId
   };
   var url = this.prefix + 'message/mass/delete?access_token=' + this.token.accessToken;
   this.request(url, postJSON(opts), wrapper(callback));


### PR DESCRIPTION
删除群发消息错误，msgid改为msg_id,根据以下文档
http://mp.weixin.qq.com/wiki/15/5380a4e6f02f2ffdc7981a8ed7a40753.html#.E5.88.A0.E9.99.A4.E7.BE.A4.E5.8F.91.E3.80.90.E8.AE.A2.E9.98.85.E5.8F.B7.E4.B8.8E.E6.9C.8D.E5.8A.A1.E5.8F.B7.E8.AE.A4.E8.AF.81.E5.90.8E.E5.9D.87.E5.8F.AF.E7.94.A8.E3.80.91