### PR TITLE
Fixed: batchGetUsers Params error.

### DIFF
--- a/lib/api_user.js
+++ b/lib/api_user.js
@@ -101,7 +101,7 @@ exports._batchGetUsers = function (openids, callback) {
   var url = this.prefix + 'user/info/batchget?access_token=' + this.token.accessToken;
   var data = {};
   data.user_list = openids.map(function (openid) {
-    return {openid: openid, lang: "zh-CN"};
+    return {openid: openid, language: "zh-CN"};
   })
   this.request(url, postJSON(data), wrapper(callback));
 };


### PR DESCRIPTION
## 问题
[微信官方文档](http://mp.weixin.qq.com/wiki/14/bb5031008f1494a59c6f71fa0f319c66.html)中的参数是错误的不是`lang`而是`language`。

## 影响范围
微信服务器返回的用户地市信息是英文。