### PR TITLE
fix updateCard接口，需要cardType参数

### DIFF
--- a/lib/api_card.js
+++ b/lib/api_card.js
@@ -248,12 +248,12 @@ make(exports, 'unavailableCode', function (code, cardId, callback) {
   this.request(url, postJSON(data), wrapper(callback));
 });
 
-make(exports, 'updateCard', function (cardId, cardInfo, callback) {
+make(exports, 'updateCard', function (cardId, cardType, cardInfo, callback) {
   var url = 'https://api.weixin.qq.com/card/update?access_token=' + this.token.accessToken;
   var data = {
-    card_id: cardId,
-    member_card: cardInfo
+    card_id: cardId
   };
+  data[cardType] = cardInfo;
   this.request(url, postJSON(data), wrapper(callback));
 });
 


### PR DESCRIPTION
微信帮助文档说：
 "member_card": {        //填写该cardid相应的卡券类型（小写）。