### PR TITLE
新申请的服务号，设备授权创建时需要带product_id

### DIFF
--- a/lib/api_device.js
+++ b/lib/api_device.js
@@ -38,7 +38,7 @@ make(exports, 'createDeviceQRCode', function (deviceIds, callback) {
   this.request(url, postJSON(info), wrapper(callback));
 });
 
-make(exports, 'authorizeDevices', function (devices, optype, callback) {
+make(exports, 'authorizeDevices', function (devices, optype, productid, callback) {
   // https://api.weixin.qq.com/device/authorize_device?access_token=ACCESS_TOKEN
   var url = 'https://api.weixin.qq.com/device/authorize_device?access_token=' + this.token.accessToken;
   var data = {
@@ -46,6 +46,9 @@ make(exports, 'authorizeDevices', function (devices, optype, callback) {
     "device_list": devices,
     "op_type": optype
   };
+  if (productid) {
+    data.product_id = productid;
+  }
   this.request(url, postJSON(data), wrapper(callback));
 });
 

--- a/lib/api_device.js
+++ b/lib/api_device.js
@@ -40,16 +40,17 @@ make(exports, 'createDeviceQRCode', function (deviceIds, callback) {
 
 make(exports, 'authorizeDevices', function (devices, optype, productid, callback) {
   // https://api.weixin.qq.com/device/authorize_device?access_token=ACCESS_TOKEN
+  var _callback = arguments[arguments.length - 1];
   var url = 'https://api.weixin.qq.com/device/authorize_device?access_token=' + this.token.accessToken;
   var data = {
     "device_num": devices.length,
     "device_list": devices,
     "op_type": optype
   };
-  if (productid) {
+  if (productid && typeof productid !== 'function') {
     data.product_id = productid;
   }
-  this.request(url, postJSON(data), wrapper(callback));
+  this.request(url, postJSON(data), wrapper(_callback));
 });
 
 make(exports, 'getDeviceQRCode', function (devices, optype, callback) {


### PR DESCRIPTION
新申请设备授权的服务号，需要在设备功能内添加设备，并根据创建的设备的product_id来申请设备授权。而早前申请过设备授权的服务号没有此问题。product_id项在wechat-api里面还没有，将其加上，并设为可选，如果函数参数传递的product_id为null,undefined或""，都不会在微信api请求里携带product_id项。