### PR TITLE
更新老的文档和api，新增api

### DIFF
--- a/lib/api_material.js
+++ b/lib/api_material.js
@@ -5,8 +5,7 @@ var formstream = require('formstream');
 var util = require('./util');
 var wrapper = util.wrapper;
 var postJSON = util.postJSON;
-//永久上传素材的url的前缀
-var prefixUrl = "https://api.weixin.qq.com/cgi-bin/";
+
 
 /**
  * 上传永久素材，分别有图片（image）、语音（voice）、和缩略图（thumb）
@@ -49,7 +48,7 @@ exports._uploadMaterial = function (filepath, type, callback) {
     }
     var form = formstream();
     form.file('media', filepath, path.basename(filepath), stat.size);
-    var url = prefixUrl + 'material/add_material?access_token=' + that.token.accessToken + '&type=' + type;
+    var url = that.prefix + 'material/add_material?access_token=' + that.token.accessToken + '&type=' + type;
     var opts = {
       dataType: 'json',
       type: 'POST',
@@ -109,7 +108,7 @@ exports._uploadVideoMaterial = function (filepath, description, callback) {
     var form = formstream();
     form.file('media', filepath, path.basename(filepath), stat.size);
     form.field('description', JSON.stringify(description));
-    var url = prefixUrl + 'material/add_material?access_token=' + that.token.accessToken + '&type=video';
+    var url = that.prefix + 'material/add_material?access_token=' + that.token.accessToken + '&type=video';
     var opts = {
       dataType: 'json',
       type: 'POST',
@@ -242,8 +241,7 @@ exports.getMaterial = function (mediaId, callback) {
  * 下载永久素材的未封装版本
  */
 exports._getMaterial = function (mediaId, callback) {
-  var prefix = 'https://api.weixin.qq.com/cgi-bin/';
-  var url = prefix + 'material/get_material?access_token=' + this.token.accessToken;
+  var url = this.prefix + 'material/get_material?access_token=' + this.token.accessToken;
   var opts = {
     type: 'POST',
     data: {'media_id': mediaId},
@@ -302,8 +300,7 @@ exports.removeMaterial = function (mediaId, callback) {
  * 删除永久素材的未封装版本
  */
 exports._removeMaterial = function (mediaId, callback) {
-  var prefix = 'https://api.weixin.qq.com/cgi-bin/';
-  var url = prefix + 'material/del_material?access_token=' + this.token.accessToken;
+  var url = this.prefix + 'material/del_material?access_token=' + this.token.accessToken;
   this.request(url, postJSON({'media_id': mediaId}), wrapper(callback));
 };
 
@@ -336,12 +333,13 @@ exports.getMaterialCount = function (callback) {
   this.preRequest(this._getMaterialCount, arguments);
 };
 
+
+
 /*!
  * 删除永久素材的未封装版本
  */
 exports._getMaterialCount = function (callback) {
-  var prefix = 'https://api.weixin.qq.com/cgi-bin/';
-  var url = prefix + 'material/get_materialcount?access_token=' + this.token.accessToken;
+  var url = this.prefix + 'material/get_materialcount?access_token=' + this.token.accessToken;
   this.request(url, {dataType: 'json'}, wrapper(callback));
 };
 
@@ -381,12 +379,13 @@ exports.getMaterials = function (type, offset, count, callback) {
   this.preRequest(this._getMaterials, arguments);
 };
 
+
+
 /*!
  * 获取永久素材列表的未封装版本
  */
 exports._getMaterials = function (type, offset, count, callback) {
-  var prefix = 'https://api.weixin.qq.com/cgi-bin/';
-  var url = prefix + 'material/batchget_material?access_token=' + this.token.accessToken;
+  var url = this.prefix + 'material/batchget_material?access_token=' + this.token.accessToken;
   var data = {
     type: type,
     offset: offset,

--- a/lib/api_message.js
+++ b/lib/api_message.js
@@ -156,7 +156,7 @@ exports._sendVideo = function (openid, mediaId, thumbMediaId, callback) {
   // {
   //  "touser":"OPENID",
   //  "msgtype":"video",
-  //  "image": {
+  //  "video": {
   //    "media_id":"MEDIA_ID"
   //    "thumb_media_id":"THUMB_MEDIA_ID"
   //  }
@@ -225,7 +225,7 @@ exports._sendMusic = function (openid, music, callback) {
 };
 
 /**
- * 客服消息，发送图文消息
+ * 客服消息，发送图文消息（点击跳转到外链）
  * 详细细节 http://mp.weixin.qq.com/wiki/1/70a29afed17f56d537c833f89be979c9.html#.E5.AE.A2.E6.9C.8D.E6.8E.A5.E5.8F.A3-.E5.8F.91.E6.B6.88.E6.81.AF
  * Examples:
  * ```
@@ -258,7 +258,7 @@ exports.sendNews = function (openid, articles, callback) {
 };
 
 /*!
- * 客服消息，发送图文消息的未封装版本
+ * 客服消息，发送图文消息（点击跳转到外链）的未封装版本
  */
 exports._sendNews = function (openid, articles, callback) {
   // {
@@ -286,6 +286,52 @@ exports._sendNews = function (openid, articles, callback) {
     "msgtype":"news",
     "news": {
       "articles": articles
+    }
+  };
+  this.request(url, postJSON(data), wrapper(callback));
+};
+
+
+
+
+/**
+ * 客服消息，发送图文消息（点击跳转到图文消息页面）
+ * 详细细节 http://mp.weixin.qq.com/wiki/14/d9be34fe03412c92517da10a5980e7ee.html#.E5.AE.A2.E6.9C.8D.E6.8E.A5.E5.8F.A3-.E5.8F.91.E6.B6.88.E6.81.AF
+ * Examples:
+ * ```
+ * api.sendMpNews('openid', 'mediaId' , callback);
+ * ```
+ * Callback:
+ *
+ * - `err`, 调用失败时得到的异常
+ * - `result`, 调用正常时得到的对象
+ *
+ * @param {String} openid 用户的openid
+ * @param {String} mediaId 图文消息的id
+ * @param {Function} callback 回调函数
+ */
+exports.sendMpNews = function (openid, mediaId, callback) {
+  this.preRequest(this._sendMpNews, arguments);
+};
+
+/*!
+ * 客服消息，发送图文消息（点击跳转到图文消息页面） 的未封装版本
+ */
+exports._sendMpNews = function (openid, mediaId, callback) {
+   //{
+   // "touser":"OPENID",
+   // "msgtype":"mpnews",
+   // "mpnews":
+   //  {
+   //     "media_id":"MEDIA_ID"
+   //  }
+   //}
+  var url = this.prefix + 'message/custom/send?access_token=' + this.token.accessToken;
+  var data = {
+    "touser": openid,
+    "msgtype":"mpnews",
+    "mpnews": {
+      "media_id": mediaId
     }
   };
   this.request(url, postJSON(data), wrapper(callback));

--- a/lib/api_template.js
+++ b/lib/api_template.js
@@ -61,14 +61,29 @@ exports._addTemplate = function (templateIdShort, callback) {
  * var templateId: '模板id';
  * // URL置空，则在发送后,点击模板消息会进入一个空白页面（ios）, 或无法点击（android）
  * var url: 'http://weixin.qq.com/download';
- * var topcolor = '#FF0000'; // 顶部颜色
  * var data = {
- *  user:{
- *    "value":'黄先生',
- *    "color":"#173177"
- *  }
+ *    "first": {
+ *      "value":"恭喜你购买成功！",
+ *      "color":"#173177"
+ *    },
+ *    "keyword1":{
+ *      "value":"巧克力",
+ *      "color":"#173177"
+ *    },
+ *    "keyword2": {
+ *      "value":"39.8元",
+ *      "color":"#173177"
+ *    },
+ *    "keyword3": {
+ *      "value":"2014年9月22日",
+ *      "color":"#173177"
+ *    },
+ *    "remark":{
+ *      "value":"欢迎再次购买！",
+ *      "color":"#173177"
+ *    }
  * };
- * api.sendTemplate('openid', templateId, url, topColor, data, callback);
+ * api.sendTemplate('openid', templateId, url, data, callback);
  * ```
  * Callback:
  *
@@ -78,21 +93,19 @@ exports._addTemplate = function (templateIdShort, callback) {
  * @param {String} openid 用户的openid
  * @param {String} templateId 模板ID
  * @param {String} url URL置空，则在发送后，点击模板消息会进入一个空白页面（ios），或无法点击（android）
- * @param {String} topColor 顶部颜色
  * @param {Object} data 渲染模板的数据
  * @param {Function} callback 回调函数
  */
-exports.sendTemplate = function (openid, templateId, url, topColor, data, callback) {
+exports.sendTemplate = function (openid, templateId, url, data, callback) {
   this.preRequest(this._sendTemplate, arguments);
 };
 
-exports._sendTemplate = function (openid, templateId, url, topColor, data, callback) {
+exports._sendTemplate = function (openid, templateId, url, data, callback) {
   var apiUrl = this.prefix + 'message/template/send?access_token=' + this.token.accessToken;
   var template = {
     touser: openid,
     template_id: templateId,
     url: url,
-    topcolor: topColor,
     data: data
   };
   this.request(apiUrl, postJSON(template), wrapper(callback));

--- a/lib/api_template.js
+++ b/lib/api_template.js
@@ -56,6 +56,7 @@ exports._addTemplate = function (templateIdShort, callback) {
 
 /**
  * 发送模板消息
+ * 详细细节: http://mp.weixin.qq.com/wiki/17/304c1885ea66dbedf7dc170d84999a9d.html
  * Examples:
  * ```
  * var templateId: '模板id';

--- a/test/api_template.test.js
+++ b/test/api_template.test.js
@@ -33,14 +33,13 @@ describe('api_template', function () {
       var templateId = '模板id';
       // URL置空，则在发送后,点击模板消息会进入一个空白页面（ios）, 或无法点击（android）
       var url = 'http://weixin.qq.com/download';
-      var topcolor = '#FF0000'; // 顶部颜色
       var data = {
         user: {
           "value":'黄先生',
           "color":"#173177"
         }
       };
-      api.sendTemplate(puling, templateId, url, topcolor, data, function (err, data, res) {
+      api.sendTemplate(puling, templateId, url, data, function (err, data, res) {
         if (!err) {
           expect(err).not.to.be.ok();
           expect(data).to.have.property('errcode', 0);
@@ -61,14 +60,13 @@ describe('api_template', function () {
         var templateId = '模板id';
         // URL置空，则在发送后,点击模板消息会进入一个空白页面（ios）, 或无法点击（android）
         var url = 'http://weixin.qq.com/download';
-        var topcolor = '#FF0000'; // 顶部颜色
         var data = {
           user: {
             "value":'黄先生',
             "color":"#173177"
           }
         };
-        api.sendTemplate(puling, templateId, url, topcolor, data, function (err, data, res) {
+        api.sendTemplate(puling, templateId, url, data, function (err, data, res) {
           expect(err).to.be.ok();
           expect(err.name).to.be('WeChatAPIError');
           expect(err.message).to.be('mock error');


### PR DESCRIPTION
+  api_material.js 中统一使用 api_common.js Line 77 定义的 this.prefix 
+  更新 api_template.js 的 sendTemplate  接口文档，去除老旧失效的 topColor 属性
+  api_message.js 新增客服发送图文信息接口 sendMpNews