### PR TITLE
修改contentType用于修正BUG

### DIFF
--- a/lib/api_media.js
+++ b/lib/api_media.js
@@ -100,7 +100,7 @@ exports._getMedia = function (mediaId, callback) {
       return callback(err);
     }
     var contentType = res.headers['content-type'];
-    if (contentType === 'application/json') {
+    if (contentType !== 'image/jpeg') {
       var ret;
       try {
         ret = JSON.parse(data);

--- a/lib/api_media.js
+++ b/lib/api_media.js
@@ -100,7 +100,7 @@ exports._getMedia = function (mediaId, callback) {
       return callback(err);
     }
     var contentType = res.headers['content-type'];
-    if (contentType !== 'image/jpeg') {
+    if (contentType === 'application/json' || contentType === 'text/plain') {
       var ret;
       try {
         ret = JSON.parse(data);


### PR DESCRIPTION
微信API当前返回错误时的contentType已经不再是'application/json',
而是'plain/text',直接将代码改为!=='image/jpeg'感觉更合适一点