### PR TITLE
微信token过期和expireTime时间不一定一致，收到40001后，需要重新获取token

### DIFF
--- a/lib/api_common.js
+++ b/lib/api_common.js
@@ -191,6 +191,11 @@ API.prototype.preRequest = function (method, args, retryed) {
     if (err) {
       return callback(err);
     }
+    //重发时清除token，重新获取            
+    if(retryed){
+        token = null;
+    }
+
     var accessToken;
     // 有token并且token有效直接调用
     if (token && (accessToken = AccessToken(token.accessToken, token.expireTime)).isValid()) {


### PR DESCRIPTION
微信token过期和expireTime时间不一定一致，收到40001后，需要重新获取token