### PR TITLE
fix shakearound api url syntax error

### DIFF
--- a/lib/api_shakearound.js
+++ b/lib/api_shakearound.js
@@ -1390,7 +1390,7 @@ make(exports, 'deleteGroupBeacons', function (options, callback) {
  * @param {Function} callback 回调函数
  */
 make(exports, 'addLotteryInfo', function (options, body, callback) {
-  var url = ' https://api.weixin.qq.com/shakearound/lottery/addlotteryinfo?&use_template=' + options.use_template + '&logo_url=' + options.logo_url + '&access_token=' + this.token.accessToken;
+  var url = 'https://api.weixin.qq.com/shakearound/lottery/addlotteryinfo?&use_template=' + options.use_template + '&logo_url=' + options.logo_url + '&access_token=' + this.token.accessToken;
   this.request(url, postJSON(body), wrapper(callback));
 });
 


### PR DESCRIPTION
摇周边-微信 API 录入红包接口: url 字符串中有多余空格符。