### PR TITLE
readme例子代码错误，导致不能获取token

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ var WechatAPI = require('wechat-api');
 var api = new WechatAPI('appid', 'secret', function (callback) {
   // 传入一个获取全局token的方法
   fs.readFile('access_token.txt', 'utf8', function (err, txt) {
-    if (err) {return callback(err);}
+    if (err) {return callback(null);}
     callback(null, JSON.parse(txt));
   });
 }, function (token, callback) {


### PR DESCRIPTION
看代码逻辑， 如果返回 err，直接return了，就不会走到获取token的流程。