### PR TITLE
卡卷第三方代制模式

### DIFF
--- a/lib/api_card.js
+++ b/lib/api_card.js
@@ -542,3 +542,184 @@ make(exports, 'addConsumer', function (username, locationId, callback) {
   this.request(url, postJSON(data), wrapper(callback));
 });
 
+/**
+ * 卡券开放类目查询接口
+ * 接口说明
+ * 通过调用该接口查询卡券开放的类目ID，类目会随业务发展变更，请每次用接口去查询获取实时卡券类目。  
+ * 注意：
+1.本接口查询的返回值还有卡券资质ID,此处的卡券资质为：已微信认证的公众号通过微信公众平台申请卡券功能时，所需的资质。
+2.对于第三方开发者代制（无公众号）模式，子商户无论选择什么类目，均暂不需按照此返回提供资质，返回值仅参考类目ID 即可。
+ * Examples:
+ * ```
+ * api.getApplyProtocol(callback);
+ * ```
+ * Callback:
+ *
+ * - `err`, 调用失败时得到的异常
+ * - `result`, 调用正常时得到的对象
+ * 
+ * Result:
+ * ```
+ * {
+ *  "category": [
+ *        {
+ *            "primary_category_id": 1,
+ *            "category_name": "美食",
+ *            "secondary_category": [
+ *                {
+ *                    "secondary_category_id": 101,
+ *                    "category_name": "粤菜",
+ *                    "need_qualification_stuffs": [
+ *                        "food_service_license_id",
+ *                        "food_service_license_bizmedia_id"
+ *                    ],
+ *                    "can_choose_prepaid_card": 1,
+ *                    "can_choose_payment_card": 1
+ *                },                
+ *        }
+ *    ],
+ *  "errcode":0,
+ *  "errmsg":"ok"
+ * }
+ * ```
+ *
+ * @name updateSubmerchant
+ * @param {Object} options 子商户相关资料
+ * @param {Function} callback 回调函数
+ */
+
+make(exports, 'getApplyProtocol', function (callback) {
+  var url = 'http://api.weixin.qq.com/card/getapplyprotocol?access_token=' + this.token.accessToken;
+  this.request(url, {dataType: 'json'}, wrapper(callback));
+});
+
+/**
+ * 创建子商户接口
+ * 接口说明
+ * 支持母商户调用该接口传入子商户的相关资料，并获取子商户ID，用于子商户的卡券功能管理。  
+ * 子商户的资质包括：商户名称、商户logo（图片）、卡券类目、授权函（扫描件或彩照）、授权函有效期截止时间。
+ * Examples:
+ * ```
+ * api.submitSubmerchant(options, callback);
+ * ```
+ * options:
+ * {
+ *  "brand_name": "aaaaaa",
+ *  "app_id"："xxxxxxxxxxx",
+ *  "logo_url": "http://mmbiz.xxxx",
+ *  "protocol": "xxxxxxxxxx",
+ *  "agreement_media_id":"xxxxxxxxxx",
+ *  "operator_media_id":"xxxxxxxx",
+ *  "end_time": 1438990559,
+ *  "primary_category_id": 1,
+ *  "secondary_category_id": 101
+ * }
+ * 
+ * Callback:
+ *
+ * - `err`, 调用失败时得到的异常
+ * - `result`, 调用正常时得到的对象
+ *
+ * @name submitSubmerchant
+ * @param {Object} options 子商户相关资料
+ * @param {Function} callback 回调函数
+ */
+
+make(exports, 'submitSubmerchant', function (options, callback) {
+  var url = 'http://api.weixin.qq.com/card/submerchant/submit?access_token=' + this.token.accessToken;
+  var data = {
+    "info": options
+  };
+  this.request(url, postJSON(data), wrapper(callback));
+});
+
+/**
+ * 更新子商户接口
+ * 接口说明
+ * 支持调用该接口更新子商户信息。   
+ * Examples:
+ * ```
+ * api.updateSubmerchant(options, callback);
+ * ```
+ * options:
+ * {
+ *  "merchant_id": 12,
+ *  "brand_name": "aaaaaa",
+ *  "app_id"："xxxxxxxxxxx",
+ *  "logo_url": "http://mmbiz.xxxx",
+ *  "protocol": "xxxxxxxxxx",
+ *  "agreement_media_id":"xxxxxxxxxx",
+ *  "operator_media_id":"xxxxxxxx",
+ *  "end_time": 1438990559,
+ *  "primary_category_id": 1,
+ *  "secondary_category_id": 101
+ * }
+ * 
+ * Callback:
+ *
+ * - `err`, 调用失败时得到的异常
+ * - `result`, 调用正常时得到的对象
+ *
+ * @name updateSubmerchant
+ * @param {Object} options 子商户相关资料
+ * @param {Function} callback 回调函数
+ */
+
+make(exports, 'updateSubmerchant', function (options, callback) {
+  var url = 'http://api.weixin.qq.com/card/submerchant/update?access_token=' + this.token.accessToken;
+  var data = {
+    "info": options
+  };
+  this.request(url, postJSON(data), wrapper(callback));
+});
+
+/**
+ * 拉取单个子商户信息接口
+ * 接口说明
+ * 通过指定的子商户merchant_id，拉取该子商户的基础信息。
+ * 注意，用母商户去调用接口，但接口内传入的是子商户的merchant_id。  
+ * Examples:
+ * ```
+ * api.getSubmerchant('merchantId', callback);
+ * ```
+ * Callback:
+ *
+ * - `err`, 调用失败时得到的异常
+ * - `result`, 调用正常时得到的对象
+ *
+ * @name getSubmerchant
+ * @param {String} merchantId 子商户相关资料
+ * @param {Function} callback 回调函数
+ */
+
+make(exports, 'getSubmerchant', function (merchantId, callback) {
+  var url = 'http://api.weixin.qq.com/card/submerchant/get?access_token=' + this.token.accessToken;
+  var data = {
+    "merchant_id": merchantId
+  };
+  this.request(url, postJSON(data), wrapper(callback));
+});
+
+
+/**
+ * 批量拉取子商户信息接口
+ * 接口说明
+ * 母商户可以通过该接口批量拉取子商户的相关信息，一次调用最多拉取100个子商户的信息，可以通过多次拉去满足不同的查询需求
+ * Examples:
+ * ```
+ * api.batchgetSubmerchant(data, callback);
+ * ```
+ * Callback:
+ *
+ * - `err`, 调用失败时得到的异常
+ * - `result`, 调用正常时得到的对象
+ *
+ * @name batchgetSubmerchant
+ * @param {Object} data 查询条件 {"begin_id": 0,"limit": 50,"status": "CHECKING"}
+ * @param {Function} callback 回调函数
+ */
+
+make(exports, 'getSubmerchant', function (data, callback) {
+  var url = 'http://api.weixin.qq.com/card/submerchant/batchget?access_token=' + this.token.accessToken;
+  this.request(url, postJSON(data), wrapper(callback));
+});

--- a/lib/api_card.js
+++ b/lib/api_card.js
@@ -583,7 +583,7 @@ make(exports, 'addConsumer', function (username, locationId, callback) {
  * }
  * ```
  *
- * @name updateSubmerchant
+ * @name getApplyProtocol
  * @param {Object} options 子商户相关资料
  * @param {Function} callback 回调函数
  */

--- a/test/api_card.test.js
+++ b/test/api_card.test.js
@@ -1,0 +1,47 @@
+var config = require('./config');
+var API = require('../');
+var expect = require('expect.js');
+
+describe('api_card', function () {
+  var api = new API(config.appid, config.appsecret);
+
+  describe('getApplyProtocol', function () {
+    it('should ok', function (done) {
+      api.getApplyProtocol(function (err, data, res) {
+        expect(err).to.not.be.ok();
+        expect(data).to.have.property('category');
+        expect(data).to.have.property('errcode', 0);
+        expect(data).to.have.property('errmsg', 'ok');
+        done();
+      });
+    });
+  });
+  
+  describe.skip('submitSubmerchant', function(){
+    var options = {
+     "brand_name": "aaaaaa",
+      // "app_id":"xxxxxxxxxxx",
+      "logo_url": "http://mmbiz.qpic.cn/mmbiz/O1DymY4NpO88CjYk0XWw9VAW99RMibqchv2OVDOibPpmMu65H47usx4fjyRwvRaZwCccibCiccMgwPk9unibewSQfjw/0?wx_fmt=jpeg",
+      "protocol": "xxxxxxxxxx",
+      "end_time": Math.round(Date.now()/1000),
+      "primary_category_id": 1,
+      "secondary_category_id": 101
+    };
+    
+    before(function(done){
+      api.uploadMedia('./test/fixture/image.jpg', 'image', function (err, data, res) {
+        options.protocol = data.media_id;
+        done(err)
+      });
+    });
+    
+    it('should ok', function(done){
+      api.submitSubmerchant(options, function (err, data, res) {
+        expect(err).to.not.be.ok();
+        expect(data).to.have.property('info');
+        expect(data.info).to.have.property('merchant_id');
+        done();
+      })
+    })
+  })
+});

--- a/test/config.js
+++ b/test/config.js
@@ -1,4 +1,4 @@
 module.exports = {
-  appid: 'wxc9135aade4e81d57',
-  appsecret: '0461795e98b8ffde5a212b5098f1b9b6'
+  appid: process.env.WX_APPID || 'wxc9135aade4e81d57',
+  appsecret: process.env.WX_APPSECRET||'0461795e98b8ffde5a212b5098f1b9b6'
 };


### PR DESCRIPTION
- 新增卡卷第三方代制模式（无公众号模式）的相关接口。
- 测试公众号帐号没有card相关能力，测试脚本没有全覆盖。