### PR TITLE
修复上传素材

### DIFF
--- a/lib/api_material.js
+++ b/lib/api_material.js
@@ -44,7 +44,7 @@ make(exports, 'uploadMaterial', function (filepath, type, callback) {
     }
     var form = formstream();
     form.file('media', filepath, path.basename(filepath), stat.size);
-    var url = that.prefix + 'material/add_material?access_token=' + that.token.accessToken + '&type=' + type;
+    var url = that.endpoint + '/cgi-bin/material/add_material?access_token=' + that.token.accessToken + '&type=' + type;
     var opts = {
       dataType: 'json',
       type: 'POST',
@@ -88,7 +88,7 @@ make(exports, 'uploadMaterial', function (filepath, type, callback) {
  * @param {Object} description 描述
  * @param {Function} callback 回调函数
  */
-make(exports, uploadVideoMaterial, function (filepath, description, callback) {
+make(exports, 'uploadVideoMaterial', function (filepath, description, callback) {
   var that = this;
   fs.stat(filepath, function (err, stat) {
     if (err) {
@@ -97,7 +97,7 @@ make(exports, uploadVideoMaterial, function (filepath, description, callback) {
     var form = formstream();
     form.file('media', filepath, path.basename(filepath), stat.size);
     form.field('description', JSON.stringify(description));
-    var url = that.prefix + 'material/add_material?access_token=' + that.token.accessToken + '&type=video';
+    var url = that.endpoint + '/cgi-bin/material/add_material?access_token=' + that.token.accessToken + '&type=video';
     var opts = {
       dataType: 'json',
       type: 'POST',

--- a/lib/api_media.js
+++ b/lib/api_media.js
@@ -169,3 +169,44 @@ exports._uploadImage = function (filepath, callback) {
     that.request(url, opts, wrapper(callback));
   });
 };
+
+/**
+ * 上传来自上游管道的图文消息内的图片，并获取URL。
+ * 拓展于uploadImage，用于客户端直接上传文件管道重定向到微信服务器，不经过自身缓存服务器文件。
+ * Examples:
+ * ```
+ * api.uploadImageStream(req, callback);
+ * ```
+ * Callback:
+ *
+ * - `err`, 调用失败时得到的异常
+ * - `result`, 调用正常时得到的对象
+ *
+ * Result:
+ * ```
+ * {"url":  "http://mmbiz.qpic.cn/mmbiz/gLO17UPS6FS2xsypf378iaNhWacZ1G1UplZYWEYfwvuU6Ont96b1roYsCNFwaRrSaKTPCUdBK9DgEHicsKwWCBRQ/0"}
+ * ```
+ *
+ * @param {String} filepath 图片文件路径
+ * @param {Function} callback 回调函数
+ */
+exports.uploadImageStream = function (req, callback) {
+  this.preRequest(this._uploadImageStream, arguments);
+};
+
+/*!
+ * 上传来自上游管道的图文消息内的图片未封装版本
+ */
+exports._uploadImageStream = function (req, callback) {
+  var that = this;
+  var url = that.endpoint + '/cgi-bin/media/uploadimg?access_token=' + that.token.accessToken;
+  var opts = {
+    dataType: 'json',
+    type: 'POST',
+    timeout: 60000, // 60秒超时
+    headers: req.headers,
+    stream: req
+  };
+  delete opts.headers.host;
+  that.request(url, opts, callback);
+};

--- a/lib/api_media.js
+++ b/lib/api_media.js
@@ -187,7 +187,7 @@ exports._uploadImage = function (filepath, callback) {
  * {"url":  "http://mmbiz.qpic.cn/mmbiz/gLO17UPS6FS2xsypf378iaNhWacZ1G1UplZYWEYfwvuU6Ont96b1roYsCNFwaRrSaKTPCUdBK9DgEHicsKwWCBRQ/0"}
  * ```
  *
- * @param {String} filepath 图片文件路径
+ * @param {Object} req 上游Stream对象，必须包含headers属性；例如expressjs中request对象。
  * @param {Function} callback 回调函数
  */
 exports.uploadImageStream = function (req, callback) {

--- a/lib/api_media.js
+++ b/lib/api_media.js
@@ -50,7 +50,7 @@ exports._uploadMedia = function (filepath, type, callback) {
     }
     var form = formstream();
     form.file('media', filepath, path.basename(filepath), stat.size);
-    var url = that.prefix + 'media/upload?access_token=' + that.token.accessToken + '&type=' + type;
+    var url = that.endpoint + '/cgi-bin/media/upload?access_token=' + that.token.accessToken + '&type=' + type;
     var opts = {
       dataType: 'json',
       type: 'POST',
@@ -158,7 +158,7 @@ exports._uploadImage = function (filepath, callback) {
     }
     var form = formstream();
     form.file('media', filepath, path.basename(filepath), stat.size);
-    var url = that.prefix + 'media/uploadimg?access_token=' + that.token.accessToken;
+    var url = that.endpoint + '/cgi-bin/media/uploadimg?access_token=' + that.token.accessToken;
     var opts = {
       dataType: 'json',
       type: 'POST',

--- a/test/api_media.test.js
+++ b/test/api_media.test.js
@@ -139,4 +139,31 @@ describe('api_media.js', function () {
       });
     });
   });
+  
+  describe('upload image', function(){
+    before(function () {
+      muk(urllib, 'request', function (url, args, callback) {
+        var resp = {
+          "url":  "http://mmbiz.qpic.cn/mmbiz/gLO17UPS6FS2xsypf378iaNhWacZ1G1UplZYWEYfwvuU6Ont96b1roYsCNFwaRrSaKTPCUdBK9DgEHicsKwWCBRQ/0"
+        };
+        process.nextTick(function () {
+          callback(null, resp);
+        });
+      });
+    });
+
+    after(function () {
+      muk.restore();
+    });
+    
+    it('should ok from upstream', function(done){
+      var req = require('fs').createReadStream(path.join(__dirname, './fixture/image.jpg'));
+      req.headers = {};
+      api.uploadImageStream(req, function (err, data, res) {
+        expect(err).not.to.be.ok();
+        expect(data).to.have.property('url');
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
- 修复因为前缀调整上传素材和图片功能失效
- 新增上传来着上游管道的数据流直接重定向到微信服务器，避免自己服务器转发。#156