### PR TITLE
handle when data is null

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -17,6 +17,12 @@ exports.wrapper = function (callback) {
       err.code = data.errcode;
       return callback(err, data, res);
     }
+    if (data == null) {
+      err = new Error("No data received.");
+      err.name = 'WeChatAPIError';
+      err.code = -1;
+      return callback(err, data, res);
+    }
     callback(null, data, res);
   };
 };


### PR DESCRIPTION
In case secretId and appId is wrong, data return can be null sometimes.
Its better to handle that case inside the wrapper.